### PR TITLE
Remove duplicated paragraph in Readme for `untracked`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ effect(() => {
 });
 ```
 
-Note that you should only use `signal.peek()` if you really need it. Reading a signal's value via `signal.value` is the preferred way in most scenarios.
-
 ### `computed(fn)`
 
 Data is often derived from other pieces of existing data. The `computed` function lets you combine the values of multiple signals into a new signal that can be reacted to, or even used by additional computeds. When the signals accessed from within a computed callback change, the computed callback is re-executed and its new return value becomes the computed signal's value.


### PR DESCRIPTION
It looks like a paragraph explaining how to use `peek()` had gotten duplicated into the bottom of the new section for `untracked(fn)`.